### PR TITLE
Add schema-registry SDK generation steps for schema-registry endpoints

### DIFF
--- a/SdkGenerationSteps.md
+++ b/SdkGenerationSteps.md
@@ -4,6 +4,11 @@
 - Current openapi spec file for the sdk can be found in api/openapi.yaml
 - The latest openapi spec file for schema-registry endpoints can be found in schema-registry repository of confluentinc here : https://github.com/confluentinc/schema-registry/blob/master/core/generated/swagger-ui/schema-registry-api-spec.yaml
 - Clone the ath-add-interfaces branch of the confluentinc/openapi-generator repo.
+```sh
+git clone https://github.com/confluentinc/openapi-generator.git
+cd openapi-generator
+git checkout ath-add-interfaces
+```
 - In openapi-generator create the required jar using `mvn clean package`
 - Run the following command to generate the latest SDK code:
 ```sh


### PR DESCRIPTION
Added a md file mentioning the steps to generate latest SDK code for schema-registry endpoints, although this repository also contains data-catalog endpoints but generation the SDK with those endpoints requires access to the internal repository schema-registry-plugins.
We are planning to make this repository publicly available, hence made sense to document the steps to be followed for SDK generation.
 
 