### PR TITLE
[DGS-6167] AsyncAPI Reverse Tooling Metric added

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ All URIs are relative to *http://localhost*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
+*DefaultApi* | [**AsyncapiParsePut**](docs/DefaultApi.md#asyncapiparseput) | **Put** /asyncapi/parse | 
 *DefaultApi* | [**AsyncapiPut**](docs/DefaultApi.md#asyncapiput) | **Put** /asyncapi | 
 *DefaultApi* | [**CreateBusinessMetadata**](docs/DefaultApi.md#createbusinessmetadata) | **Post** /catalog/v1/entity/businessmetadata | Bulk API to create multiple business metadata.
 *DefaultApi* | [**CreateBusinessMetadataDefs**](docs/DefaultApi.md#createbusinessmetadatadefs) | **Post** /catalog/v1/types/businessmetadatadefs | Bulk create API for business metadata definitions.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -3036,6 +3036,19 @@ paths:
         "500":
           description: Internal Server Error
       summary: Get the tag definition with the given name.
+  /asyncapi/parse:
+    put:
+      description: Get number of times the cli tool is used to export/produce the
+        spec file
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+        "429":
+          description: Rate Limit Error
+        "500":
+          description: Internal Server Error
   /asyncapi:
     put:
       description: Get number of times the cli tool is used to export/produce the

--- a/api_default.go
+++ b/api_default.go
@@ -28,6 +28,15 @@ var (
 type DefaultApi interface {
 
 	/*
+	 * AsyncapiParsePut Method for AsyncapiParsePut
+	 *
+	 * Get number of times the cli tool is used to export/produce the spec file
+	 *
+	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	 */
+	AsyncapiParsePut(ctx _context.Context) (*_nethttp.Response, error)
+
+	/*
 	 * AsyncapiPut Method for AsyncapiPut
 	 *
 	 * Get number of times the cli tool is used to export/produce the spec file
@@ -764,6 +773,72 @@ type DefaultApi interface {
 
 // DefaultApiService DefaultApi service
 type DefaultApiService service
+
+/*
+ * AsyncapiParsePut Method for AsyncapiParsePut
+ *
+ * Get number of times the cli tool is used to export/produce the spec file
+ *
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ */
+func (a *DefaultApiService) AsyncapiParsePut(ctx _context.Context) (*_nethttp.Response, error) {
+	var (
+		localVarHTTPMethod   = _nethttp.MethodPut
+		localVarPostBody     interface{}
+		localVarFormFileName string
+		localVarFileName     string
+		localVarFileBytes    []byte
+	)
+
+	// create path and map variables
+	localVarPath := a.client.cfg.BasePath + "/asyncapi/parse"
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := _neturl.Values{}
+	localVarFormParams := _neturl.Values{}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(r)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarHTTPResponse, err
+	}
+
+	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	if err != nil {
+		return localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		return localVarHTTPResponse, newErr
+	}
+
+	return localVarHTTPResponse, nil
+}
 
 /*
  * AsyncapiPut Method for AsyncapiPut

--- a/docs/DefaultApi.md
+++ b/docs/DefaultApi.md
@@ -4,6 +4,7 @@ All URIs are relative to *http://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
+[**AsyncapiParsePut**](DefaultApi.md#AsyncapiParsePut) | **Put** /asyncapi/parse | 
 [**AsyncapiPut**](DefaultApi.md#AsyncapiPut) | **Put** /asyncapi | 
 [**CreateBusinessMetadata**](DefaultApi.md#CreateBusinessMetadata) | **Post** /catalog/v1/entity/businessmetadata | Bulk API to create multiple business metadata.
 [**CreateBusinessMetadataDefs**](DefaultApi.md#CreateBusinessMetadataDefs) | **Post** /catalog/v1/types/businessmetadatadefs | Bulk create API for business metadata definitions.
@@ -71,6 +72,36 @@ Method | HTTP request | Description
 [**UpdateTopLevelConfig**](DefaultApi.md#UpdateTopLevelConfig) | **Put** /config | Update global compatibility level.
 [**UpdateTopLevelMode**](DefaultApi.md#UpdateTopLevelMode) | **Put** /mode | Update global mode.
 
+
+
+## AsyncapiParsePut
+
+> AsyncapiParsePut(ctx, )
+
+
+
+Get number of times the cli tool is used to export/produce the spec file
+
+### Required Parameters
+
+This endpoint does not need any parameter.
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
+[[Back to Model list]](../README.md#documentation-for-models)
+[[Back to README]](../README.md)
 
 
 ## AsyncapiPut

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,15 @@
 module github.com/confluentinc/schema-registry-sdk-go
 
-go 1.17
+go 1.20
 
 require (
 	github.com/antihax/optional v1.0.0
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
-	
+
+)
+
+require (
+	github.com/golang/protobuf v1.2.0 // indirect
+	golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e // indirect
+	google.golang.org/appengine v1.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,6 @@
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/antihax/optional v1.0.0 h1:xK2lYat7ZLaVVcIuj82J8kIro4V6kDe0AUDFboUCwcg=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/aws/aws-sdk-go v1.26.3 h1:szQdfJcUBAhQT0zZEx4sxoDuWb7iScoucxCiVxDmaBk=
-github.com/aws/aws-sdk-go v1.26.3/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/mock/api_default.go
+++ b/mock/api_default.go
@@ -14,6 +14,9 @@ import (
 
 // DefaultApi is a mock of DefaultApi interface
 type DefaultApi struct {
+	lockAsyncapiParsePut sync.Mutex
+	AsyncapiParsePutFunc func(ctx context.Context) (*net_http.Response, error)
+
 	lockAsyncapiPut sync.Mutex
 	AsyncapiPutFunc func(ctx context.Context) (*net_http.Response, error)
 
@@ -213,6 +216,9 @@ type DefaultApi struct {
 	UpdateTopLevelModeFunc func(ctx context.Context, body github_com_confluentinc_schema_registry_sdk_go.ModeUpdateRequest) (github_com_confluentinc_schema_registry_sdk_go.ModeUpdateRequest, *net_http.Response, error)
 
 	calls struct {
+		AsyncapiParsePut []struct {
+			Ctx context.Context
+		}
 		AsyncapiPut []struct {
 			Ctx context.Context
 		}
@@ -504,6 +510,44 @@ type DefaultApi struct {
 			Body github_com_confluentinc_schema_registry_sdk_go.ModeUpdateRequest
 		}
 	}
+}
+
+// AsyncapiParsePut mocks base method by wrapping the associated func.
+func (m *DefaultApi) AsyncapiParsePut(ctx context.Context) (*net_http.Response, error) {
+	m.lockAsyncapiParsePut.Lock()
+	defer m.lockAsyncapiParsePut.Unlock()
+
+	if m.AsyncapiParsePutFunc == nil {
+		panic("mocker: DefaultApi.AsyncapiParsePutFunc is nil but DefaultApi.AsyncapiParsePut was called.")
+	}
+
+	call := struct {
+		Ctx context.Context
+	}{
+		Ctx: ctx,
+	}
+
+	m.calls.AsyncapiParsePut = append(m.calls.AsyncapiParsePut, call)
+
+	return m.AsyncapiParsePutFunc(ctx)
+}
+
+// AsyncapiParsePutCalled returns true if AsyncapiParsePut was called at least once.
+func (m *DefaultApi) AsyncapiParsePutCalled() bool {
+	m.lockAsyncapiParsePut.Lock()
+	defer m.lockAsyncapiParsePut.Unlock()
+
+	return len(m.calls.AsyncapiParsePut) > 0
+}
+
+// AsyncapiParsePutCalls returns the calls made to AsyncapiParsePut.
+func (m *DefaultApi) AsyncapiParsePutCalls() []struct {
+	Ctx context.Context
+} {
+	m.lockAsyncapiParsePut.Lock()
+	defer m.lockAsyncapiParsePut.Unlock()
+
+	return m.calls.AsyncapiParsePut
 }
 
 // AsyncapiPut mocks base method by wrapping the associated func.
@@ -3292,6 +3336,9 @@ func (m *DefaultApi) UpdateTopLevelModeCalls() []struct {
 
 // Reset resets the calls made to the mocked methods.
 func (m *DefaultApi) Reset() {
+	m.lockAsyncapiParsePut.Lock()
+	m.calls.AsyncapiParsePut = nil
+	m.lockAsyncapiParsePut.Unlock()
 	m.lockAsyncapiPut.Lock()
 	m.calls.AsyncapiPut = nil
 	m.lockAsyncapiPut.Unlock()


### PR DESCRIPTION
Adding function AsyncApiParsePut for endpoint `/asyncapi/parse`. It is used to measure the adoption rate of AsyncAPI import functionality.

Steps followed:
Modified openapi.yaml file
2nd half of: [SDK Generation Steps](https://github.com/confluentinc/schema-registry-sdk-go/blob/master/SdkGenerationSteps.md)