### PR TITLE
[DP-12820] cleanup pipeline by removing unnecessary secrets and commands

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -15,7 +15,6 @@ blocks:
           - export "PATH=${GOPATH}/bin:${PATH}"
           - mkdir -vp "${SEMAPHORE_GIT_DIR}" "${GOPATH}/bin"
           - git config --global url."git@github.com:".insteadOf "https://github.com/"
-          - chmod 400 ~/.ssh/id_rsa
           - export SEMAPHORE_CACHE_DIR=/home/semaphore
       jobs:
         - commands:


### PR DESCRIPTION
## Background
This is a followup to DP-12820 to clean up semaphore pipelines. This change removes some secrets that have been
deactivated as well as removes some commands that are set automatically by the semaphore agent, and replaces
two lines make install-vault and mk-include/bin/vault-setup with . vault-setup.

The same [change](https://github.com/confluentinc/cc-service-bot/pull/471/files) was made for managed semaphore pipelines, this automated PR
should match the changes made in the managed semaphore pipelines.

## Actions
This should not affect your pipelines. If the commands match what was made in the managed semaphore pipelines,
and the pr build passes, please merge this change.
