### PR TITLE
Add kekRenameFormat to exporter configs

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -4371,6 +4371,8 @@ components:
           type: string
         context:
           type: string
+        kekRenameFormat:
+          type: string
         subjectRenameFormat:
           type: string
         config:
@@ -4410,6 +4412,8 @@ components:
           - CUSTOM
           type: string
         context:
+          type: string
+        kekRenameFormat:
           type: string
         subjectRenameFormat:
           type: string
@@ -4468,6 +4472,8 @@ components:
           - CUSTOM
           type: string
         context:
+          type: string
+        kekRenameFormat:
           type: string
         subjectRenameFormat:
           type: string


### PR DESCRIPTION
Add property kekRenameFormat to exporter configs.  This allows for renaming keks during schema linking, and can take the form of `${kek}-suffix` for example, similar to how subjectRenameFormat uses the template `${subject}`